### PR TITLE
Feature/#4 GET - 페이머니 조회 API

### DIFF
--- a/src/main/java/org/sopt/kakaopay/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/kakaopay/common/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.sopt.kakaopay.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -26,5 +27,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ForbiddenException.class)
     protected ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.of(HttpStatus.FORBIDDEN.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingRequestHeaderException (MissingRequestHeaderException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
     }
 }

--- a/src/main/java/org/sopt/kakaopay/common/dto/SuccessMessage.java
+++ b/src/main/java/org/sopt/kakaopay/common/dto/SuccessMessage.java
@@ -11,7 +11,7 @@ public enum SuccessMessage {
     BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다."),
     POST_CREATE_SUCCESS(HttpStatus.CREATED.value(),"게시글 생성이 완료되었습니다."),
 
-    POST_FIND_SUCCESS(HttpStatus.OK.value(), "게시글 찾기가 완료되었습니다.");
+    PAYMONEY_FIND_SUCCESS(HttpStatus.OK.value(), "페이머니 조회가 완료되었습니다."),;
 
     private final int status;
     private final String message;

--- a/src/main/java/org/sopt/kakaopay/controller/MemberController.java
+++ b/src/main/java/org/sopt/kakaopay/controller/MemberController.java
@@ -1,13 +1,29 @@
 package org.sopt.kakaopay.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.kakaopay.common.dto.SuccessMessage;
+import org.sopt.kakaopay.common.dto.SuccessStatusResponse;
 import org.sopt.kakaopay.service.MemberService;
+import org.sopt.kakaopay.service.dto.PayMoneyFindDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/vi/member")
+@RequestMapping("api/v1/member")
 public class MemberController {
     private final MemberService memberService;
+
+    @GetMapping("/paymoney")
+    public ResponseEntity<SuccessStatusResponse<PayMoneyFindDto>> getMemberPayMoney(
+            @RequestHeader Long memberId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.PAYMONEY_FIND_SUCCESS,
+                        memberService.findPayMoneyById(memberId)));
+    }
 }

--- a/src/main/java/org/sopt/kakaopay/service/MemberService.java
+++ b/src/main/java/org/sopt/kakaopay/service/MemberService.java
@@ -1,11 +1,26 @@
 package org.sopt.kakaopay.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.kakaopay.common.dto.ErrorMessage;
+import org.sopt.kakaopay.domain.Member;
+import org.sopt.kakaopay.exception.NotFoundException;
 import org.sopt.kakaopay.repository.MemberRepository;
+import org.sopt.kakaopay.service.dto.PayMoneyFindDto;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+
+    public Member findMemberById(Long memerId){
+        return memberRepository.findById(memerId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
+        );
+    }
+
+    public PayMoneyFindDto findPayMoneyById(Long memerId){
+        Member member = findMemberById(memerId);
+        return PayMoneyFindDto.of(member);
+    }
 }

--- a/src/main/java/org/sopt/kakaopay/service/dto/PayMoneyFindDto.java
+++ b/src/main/java/org/sopt/kakaopay/service/dto/PayMoneyFindDto.java
@@ -1,0 +1,9 @@
+package org.sopt.kakaopay.service.dto;
+
+import org.sopt.kakaopay.domain.Member;
+
+public record PayMoneyFindDto(String payMoney){
+    public static PayMoneyFindDto of(Member member){
+        return new PayMoneyFindDto(member.getPayMoney());
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #4 

## Key Changes 🔑
1. getPayMoney api 추가

## To Reviewers 📢
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/d9fd4888ed88d97c2be423d08624fdc25fe5d99d/src/main/java/org/sopt/kakaopay/controller/MemberController.java#L21-L29
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/d9fd4888ed88d97c2be423d08624fdc25fe5d99d/src/main/java/org/sopt/kakaopay/service/MemberService.java#L16-L25
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/d9fd4888ed88d97c2be423d08624fdc25fe5d99d/src/main/java/org/sopt/kakaopay/service/dto/PayMoneyFindDto.java#L5-L9
request haerder가 들어오지 않았을 때나 memberId에 해당하는 멤버가 없을 때 각각의 예외 메세지를 출력해줄 수 있도록 코드를 작성했습니다.
