### PR TITLE
Feature/#3 GET - 페이포인트 조회 API

### DIFF
--- a/src/main/java/org/sopt/kakaopay/common/dto/SuccessMessage.java
+++ b/src/main/java/org/sopt/kakaopay/common/dto/SuccessMessage.java
@@ -9,9 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum SuccessMessage {
 
     BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다."),
-    POST_CREATE_SUCCESS(HttpStatus.CREATED.value(),"게시글 생성이 완료되었습니다."),
 
-    POST_FIND_SUCCESS(HttpStatus.OK.value(), "게시글 찾기가 완료되었습니다.");
+    PAYPOINT_FIND_SUCCESS(HttpStatus.OK.value(), "페이포인트 조회가 완료되었습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/org/sopt/kakaopay/controller/MemberController.java
+++ b/src/main/java/org/sopt/kakaopay/controller/MemberController.java
@@ -1,13 +1,33 @@
 package org.sopt.kakaopay.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.kakaopay.common.dto.SuccessMessage;
+import org.sopt.kakaopay.common.dto.SuccessStatusResponse;
 import org.sopt.kakaopay.service.MemberService;
+import org.sopt.kakaopay.service.dto.PayPointFindDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/vi/member")
+@RequestMapping("api/v1/member")
 public class MemberController {
     private final MemberService memberService;
+
+    @GetMapping("/paypoint")
+    public ResponseEntity<SuccessStatusResponse<PayPointFindDto>> getMemberPayPoint(
+        @RequestHeader("memberId") Long memberId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(SuccessStatusResponse.of(SuccessMessage.PAYPOINT_FIND_SUCCESS,
+                memberService.findPayPointById(memberId)));
+    }
+
+
+
+
 }

--- a/src/main/java/org/sopt/kakaopay/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/kakaopay/repository/MemberRepository.java
@@ -1,8 +1,16 @@
 package org.sopt.kakaopay.repository;
 
 import java.util.Optional;
+import org.sopt.kakaopay.common.dto.ErrorMessage;
 import org.sopt.kakaopay.domain.Member;
+import org.sopt.kakaopay.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    default Member findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(
+            () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
+        );
+    }
 }

--- a/src/main/java/org/sopt/kakaopay/service/MemberService.java
+++ b/src/main/java/org/sopt/kakaopay/service/MemberService.java
@@ -1,11 +1,27 @@
 package org.sopt.kakaopay.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.kakaopay.common.dto.ErrorMessage;
+import org.sopt.kakaopay.domain.Member;
+import org.sopt.kakaopay.exception.NotFoundException;
 import org.sopt.kakaopay.repository.MemberRepository;
+import org.sopt.kakaopay.service.dto.PayPointFindDto;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+
+    public Member findMemberById(Long memberId){
+        return memberRepository.findById(memberId).orElseThrow(
+            () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
+        );
+    }
+
+    public PayPointFindDto findPayPointById(Long memberId) {
+        Member member = findMemberById(memberId);
+        return PayPointFindDto.of(member);
+    }
+
 }

--- a/src/main/java/org/sopt/kakaopay/service/dto/PayPointFindDto.java
+++ b/src/main/java/org/sopt/kakaopay/service/dto/PayPointFindDto.java
@@ -1,0 +1,13 @@
+package org.sopt.kakaopay.service.dto;
+
+import org.sopt.kakaopay.domain.Member;
+
+public record PayPointFindDto(
+    String payMoney
+) {
+
+    public static PayPointFindDto of(Member member) {
+        return new PayPointFindDto(
+            member.getPayPoint());
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #3  

## Key Changes 🔑
1. getPayPoint api 추가

## To Reviewers 📢

MemberController
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/650f9e3e0f72d4b02a709f001d9ac35b7a55f72e/src/main/java/org/sopt/kakaopay/controller/MemberController.java#L22-L29

PayPointFindDto
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/650f9e3e0f72d4b02a709f001d9ac35b7a55f72e/src/main/java/org/sopt/kakaopay/service/dto/PayPointFindDto.java#L5-L12

MemberService
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/650f9e3e0f72d4b02a709f001d9ac35b7a55f72e/src/main/java/org/sopt/kakaopay/service/MemberService.java#L24-L27


request haerder가 들어오지 않았을 때나 memberId에 해당하는 멤버가 없을 때 각각의 예외 메세지를 출력해줄 수 있도록 코드를 작성했습니다.
