### PR TITLE
Feature/#6 DELETE - 즐겨찾기 해제 API

### DIFF
--- a/src/main/java/org/sopt/kakaopay/common/dto/ErrorMessage.java
+++ b/src/main/java/org/sopt/kakaopay/common/dto/ErrorMessage.java
@@ -9,9 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
 
     //message 사용 예시
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
-    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(),"ID에 해당하는 블로그가 존재하지 않습니다."),
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 포스트가 존재하지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청하신 사용자가 존재하지 않습니다."),
+    BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND.value(),"요청하신 북마크가 존재하지 않습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청하신 포스트가 존재하지 않습니다."),
 
     FORBIDDEN_MEMBER_ACCESS(HttpStatus.FORBIDDEN.value(), "이 멤버는 해당 블로그에 대한 접근 권한이 없습니다.")
     ;

--- a/src/main/java/org/sopt/kakaopay/common/dto/SuccessMessage.java
+++ b/src/main/java/org/sopt/kakaopay/common/dto/SuccessMessage.java
@@ -11,7 +11,10 @@ public enum SuccessMessage {
     BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다."),
     POST_CREATE_SUCCESS(HttpStatus.CREATED.value(),"게시글 생성이 완료되었습니다."),
 
-    PAYMONEY_FIND_SUCCESS(HttpStatus.OK.value(), "페이머니 조회가 완료되었습니다."),;
+    PAYMONEY_FIND_SUCCESS(HttpStatus.OK.value(), "페이머니 조회가 완료되었습니다."),
+
+    BOOKMARK_DELETE_SUCCESS(HttpStatus.OK.value(), "즐겨찾기가 삭제되었습니다.");
+
 
     private final int status;
     private final String message;

--- a/src/main/java/org/sopt/kakaopay/controller/BookmarkController.java
+++ b/src/main/java/org/sopt/kakaopay/controller/BookmarkController.java
@@ -1,7 +1,15 @@
 package org.sopt.kakaopay.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.kakaopay.common.dto.SuccessMessage;
+import org.sopt.kakaopay.common.dto.SuccessStatusResponse;
 import org.sopt.kakaopay.service.BookmarkService;
+import org.sopt.kakaopay.service.dto.BookmarkDeleteDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/bookmark")
 public class BookmarkController {
     private final BookmarkService bookmarkService;
+
+    @DeleteMapping
+    public ResponseEntity<SuccessStatusResponse> deleteBookmark(
+            @RequestHeader("memberId") Long memberId,
+            @RequestBody BookmarkDeleteDto bookmarkDeleteDto
+    ) {
+        bookmarkService.deleteBookmark(memberId, bookmarkDeleteDto);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.BOOKMARK_DELETE_SUCCESS));
+    }
 }

--- a/src/main/java/org/sopt/kakaopay/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/kakaopay/repository/MemberRepository.java
@@ -5,4 +5,5 @@ import org.sopt.kakaopay.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByBankAndBankAccount(String bank, String bankAccount);
 }

--- a/src/main/java/org/sopt/kakaopay/service/BookmarkService.java
+++ b/src/main/java/org/sopt/kakaopay/service/BookmarkService.java
@@ -1,11 +1,29 @@
 package org.sopt.kakaopay.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.kakaopay.common.dto.ErrorMessage;
+import org.sopt.kakaopay.domain.Bookmark;
+import org.sopt.kakaopay.domain.Member;
+import org.sopt.kakaopay.exception.NotFoundException;
 import org.sopt.kakaopay.repository.BookmarkRepository;
+import org.sopt.kakaopay.service.dto.BookmarkDeleteDto;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public void deleteBookmark(Long memberId, BookmarkDeleteDto bookmarkDeleteDto) {
+        Member sourceMember = memberService.findMemberById(memberId);
+        Member targetMember = memberService.findMemberByBankAndBankAccount(bookmarkDeleteDto.bank(),
+                bookmarkDeleteDto.bankAccount());
+        Bookmark bookmark = bookmarkRepository.findBySourceMemberAndTargetMember(sourceMember, targetMember).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.BOOKMARK_NOT_FOUND)
+        );
+        bookmarkRepository.delete(bookmark);
+    }
 }

--- a/src/main/java/org/sopt/kakaopay/service/MemberService.java
+++ b/src/main/java/org/sopt/kakaopay/service/MemberService.java
@@ -13,8 +13,14 @@ import org.springframework.stereotype.Service;
 public class MemberService {
     private final MemberRepository memberRepository;
 
-    public Member findMemberById(Long memerId){
-        return memberRepository.findById(memerId).orElseThrow(
+    public Member findMemberById(Long memberId){
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
+        );
+    }
+
+    public Member findMemberByBankAndBankAccount(String bank, String bankAccount) {
+        return memberRepository.findByBankAndBankAccount(bank, bankAccount).orElseThrow(
                 () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
         );
     }

--- a/src/main/java/org/sopt/kakaopay/service/dto/BookmarkDeleteDto.java
+++ b/src/main/java/org/sopt/kakaopay/service/dto/BookmarkDeleteDto.java
@@ -1,0 +1,4 @@
+package org.sopt.kakaopay.service.dto;
+
+public record BookmarkDeleteDto (String bank, String bankAccount){
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #6

## Key Changes 🔑
1. deleteBookmark  api 추가

## To Reviewers 📢
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/32a12184566ecaaee9d1336626064b8a00b3c213/src/main/java/org/sopt/kakaopay/controller/BookmarkController.java#L22-L30

https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/32a12184566ecaaee9d1336626064b8a00b3c213/src/main/java/org/sopt/kakaopay/service/MemberService.java#L22-L31

https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/32a12184566ecaaee9d1336626064b8a00b3c213/src/main/java/org/sopt/kakaopay/service/BookmarkService.java#L19-L29

https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/32a12184566ecaaee9d1336626064b8a00b3c213/src/main/java/org/sopt/kakaopay/service/dto/BookmarkDeleteDto.java#L3-L4


삭제할 북마크가 존재하지 않는 경우에 대한 예외 메세지도 작성하였습니다.
성공 메시지를 리턴할 수 있도록 성공시 204 코드가 아닌 200 코드를 리턴해주었습니다.
