### PR TITLE
Feature/#8 POST - 즐겨찾기 추가 API

### DIFF
--- a/src/main/java/org/sopt/kakaopay/common/dto/SuccessMessage.java
+++ b/src/main/java/org/sopt/kakaopay/common/dto/SuccessMessage.java
@@ -11,8 +11,9 @@ public enum SuccessMessage {
     BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다."),
 
 
-    PAYPOINT_FIND_SUCCESS(HttpStatus.OK.value(), "페이포인트 조회가 완료되었습니다.");
-    PAYMONEY_FIND_SUCCESS(HttpStatus.OK.value(), "페이머니 조회가 완료되었습니다."),;
+    PAYPOINT_FIND_SUCCESS(HttpStatus.OK.value(), "페이포인트 조회가 완료되었습니다."),
+    PAYMONEY_FIND_SUCCESS(HttpStatus.OK.value(), "페이머니 조회가 완료되었습니다."),
+    BOOKMARK_ADDED_SUCCESS(HttpStatus.CREATED.value(), "즐겨찾기가 추가되었습니다.");
 
 
     private final int status;

--- a/src/main/java/org/sopt/kakaopay/controller/BookmarkController.java
+++ b/src/main/java/org/sopt/kakaopay/controller/BookmarkController.java
@@ -1,13 +1,37 @@
 package org.sopt.kakaopay.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.sopt.kakaopay.common.dto.SuccessMessage;
+import org.sopt.kakaopay.common.dto.SuccessStatusResponse;
+import org.sopt.kakaopay.domain.Bookmark;
 import org.sopt.kakaopay.service.BookmarkService;
+import org.sopt.kakaopay.service.dto.BookmarkAddDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/bookmark")
 public class BookmarkController {
     private final BookmarkService bookmarkService;
+
+    @PostMapping
+    public ResponseEntity<SuccessStatusResponse> addBookmark(
+        @RequestHeader("memberId") Long memberId,
+        @RequestBody BookmarkAddDto bookmarkAddDto
+    ) {
+        bookmarkService.AddBookmark(memberId, bookmarkAddDto);
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(SuccessStatusResponse.of(SuccessMessage.BOOKMARK_ADDED_SUCCESS));
+
+    }
 }

--- a/src/main/java/org/sopt/kakaopay/controller/MemberController.java
+++ b/src/main/java/org/sopt/kakaopay/controller/MemberController.java
@@ -1,5 +1,6 @@
 package org.sopt.kakaopay.controller;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.sopt.kakaopay.common.dto.SuccessMessage;
 import org.sopt.kakaopay.common.dto.SuccessStatusResponse;
@@ -9,6 +10,8 @@ import org.sopt.kakaopay.service.dto.PayMoneyFindDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,15 +32,14 @@ public class MemberController {
     }
 
 
-
-
-
     @GetMapping("/paymoney")
     public ResponseEntity<SuccessStatusResponse<PayMoneyFindDto>> getMemberPayMoney(
-            @RequestHeader Long memberId
+            @RequestHeader("memberId") Long memberId
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessStatusResponse.of(SuccessMessage.PAYMONEY_FIND_SUCCESS,
                         memberService.findPayMoneyById(memberId)));
     }
+
+
 }

--- a/src/main/java/org/sopt/kakaopay/repository/BookmarkRepository.java
+++ b/src/main/java/org/sopt/kakaopay/repository/BookmarkRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findBySourceMemberAndTargetMember(Member sourceMember, Member targetMemberTarget);
+
 }

--- a/src/main/java/org/sopt/kakaopay/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/kakaopay/repository/MemberRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByBankAndBankAccount(String bank, String bankAccount);
+
+
     default Member findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(
             () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)

--- a/src/main/java/org/sopt/kakaopay/service/BookmarkService.java
+++ b/src/main/java/org/sopt/kakaopay/service/BookmarkService.java
@@ -1,11 +1,30 @@
 package org.sopt.kakaopay.service;
 
+import jakarta.transaction.Transactional;
+import java.awt.print.Book;
 import lombok.RequiredArgsConstructor;
+import org.sopt.kakaopay.domain.Bookmark;
+import org.sopt.kakaopay.domain.Member;
 import org.sopt.kakaopay.repository.BookmarkRepository;
+import org.sopt.kakaopay.service.dto.BookmarkAddDto;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public void AddBookmark(Long memberId, BookmarkAddDto bookmarkAddDto) {
+        Member sourceMember = memberService.findMemberById(memberId);
+        Member targetMember = memberService.findMemberByBankAndBankAccount(bookmarkAddDto.bank(),
+            bookmarkAddDto.bankAccount());
+        Bookmark bookmark = new Bookmark(sourceMember, targetMember);
+
+        bookmarkRepository.save(bookmark);
+
+    }
+
+
 }

--- a/src/main/java/org/sopt/kakaopay/service/MemberService.java
+++ b/src/main/java/org/sopt/kakaopay/service/MemberService.java
@@ -21,6 +21,13 @@ public class MemberService {
         );
     }
 
+    public Member findMemberByBankAndBankAccount(String bank, String bankAccount) {
+        return memberRepository.findByBankAndBankAccount(bank, bankAccount).orElseThrow(
+            () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
+        );
+    }
+
+
     public PayPointFindDto findPayPointById(Long memberId) {
         Member member = findMemberById(memberId);
         return PayPointFindDto.of(member);

--- a/src/main/java/org/sopt/kakaopay/service/dto/BookmarkAddDto.java
+++ b/src/main/java/org/sopt/kakaopay/service/dto/BookmarkAddDto.java
@@ -1,0 +1,5 @@
+package org.sopt.kakaopay.service.dto;
+
+public record BookmarkAddDto (String bank, String bankAccount){
+
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #8 

## Key Changes 🔑
1. addBookmark  api 추가

## To Reviewers 📢

Controller
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/22b77ece0bbe104b0ee17e096f749efdd923be9c/src/main/java/org/sopt/kakaopay/controller/BookmarkController.java#L28-L38

Service
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/22b77ece0bbe104b0ee17e096f749efdd923be9c/src/main/java/org/sopt/kakaopay/service/BookmarkService.java#L22-L31

Dto
https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/22b77ece0bbe104b0ee17e096f749efdd923be9c/src/main/java/org/sopt/kakaopay/service/dto/BookmarkAddDto.java#L3-L5


성공시 201 코드를 리턴해주었습니다.
