### PR TITLE
Hotfix/#21 - 최근 거래 내역 순서 관련 오류 수정 

### DIFF
--- a/src/main/java/org/sopt/kakaopay/service/HistoryService.java
+++ b/src/main/java/org/sopt/kakaopay/service/HistoryService.java
@@ -2,6 +2,7 @@ package org.sopt.kakaopay.service;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.swing.LookAndFeel;
@@ -24,7 +25,7 @@ public class HistoryService {
         Member sourceMember = memberService.findMemberById(memberId);
         List<History> histories = historyRepository.findAllBySenderOrReceiverOrderByCreatedAtDesc(sourceMember, sourceMember);
 
-        Set<Member> uniqueMember = new HashSet<>();
+        Set<Member> uniqueMember = new LinkedHashSet<>();
         List<Boolean> bookmarks = new ArrayList<>();
 /*
         sourceMember의 최신 거래 내역에서 겹치지 않는 3명의 상대방 필터링
@@ -49,7 +50,7 @@ public class HistoryService {
             bookmarks.add(bookmark);
         }
 
-        return HistoryFindDto.findAll(uniqueMember.stream().toList(), bookmarks);
+        return HistoryFindDto.findAll(new ArrayList<>(uniqueMember), bookmarks);
 
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- close #21

## Key Changes 🔑
1. 같은 북마크 등록시 오류 발생
2. 요청한 북마크가 여러 번 존재할 경우 한 번에 삭제

## To Reviewers 📢

https://github.com/NOW-SOPT-APP5-KakaoPay/KakaoPay-Server/blob/aac9f073182fa144ac2dc452adbc0ba30630e5eb/src/main/java/org/sopt/kakaopay/service/HistoryService.java#L28
- HashSet은 순서를 보장하지 않기 때문에, uniqueMember에 추가된 멤버들의 순서를 예측할 수 없음.
- 삽입 순서를 유지하는 Set인 LinkedHashSet으로 변경




